### PR TITLE
Add belly color selector and adjust tail

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,7 @@
 # Warriors
 Amelia's Warriors-inspired game
+
+## Character Creator
+
+The character creator allows customizing various parts of the cat. A belly
+color selector is provided so the belly can be different from the main body.

--- a/index.html
+++ b/index.html
@@ -76,6 +76,13 @@
       <button class="color-btn" data-part="body" data-color="#f5deb3" style="background:#f5deb3"></button>
     </div>
     <div class="color-column">
+      <div class="column-label">Belly</div>
+      <button class="color-btn" data-part="belly" data-color="#fff8dc" style="background:#fff8dc"></button>
+      <button class="color-btn" data-part="belly" data-color="#ffe4c4" style="background:#ffe4c4"></button>
+      <button class="color-btn" data-part="belly" data-color="#f5deb3" style="background:#f5deb3"></button>
+      <button class="color-btn" data-part="belly" data-color="#ffffff" style="background:#ffffff"></button>
+    </div>
+    <div class="color-column">
       <div class="column-label">Muzzle</div>
       <button class="color-btn" data-part="muzzle" data-color="#cccccc" style="background:#cccccc"></button>
       <button class="color-btn" data-part="muzzle" data-color="#ffe4c4" style="background:#ffe4c4"></button>

--- a/src/main.ts
+++ b/src/main.ts
@@ -3,6 +3,7 @@ import * as PIXI from 'pixi.js';
 type CatColors = {
   ears: number;
   body: number;
+  belly: number;
   muzzle: number;
   paws: number;
   tail: number;
@@ -69,6 +70,7 @@ async function start(): Promise<void> {
   const defaultColors: CatColors = {
     ears: 0xffffff,
     body: 0xffffff,
+    belly: 0xffe4c4,
     muzzle: 0xcccccc,
     paws: 0xaaaaaa,
     tail: 0xffffff,
@@ -92,7 +94,7 @@ async function start(): Promise<void> {
     c.addChild(body);
 
     const belly = new PIXI.Graphics();
-    belly.beginFill(shadeColor(colors.body, 0.2));
+    belly.beginFill(colors.belly);
     belly.drawEllipse(0, 55, 35, 40);
     belly.endFill();
     c.addChild(belly);
@@ -171,11 +173,15 @@ async function start(): Promise<void> {
     pawRightPads.endFill();
     c.addChild(pawRightPads);
 
-    // Tail
+    // Tail drawn behind the body, lying on the ground with a curl
     const tail = new PIXI.Graphics();
     tail.beginFill(colors.tail);
-    tail.drawEllipse(55, 70, 25, 10);
+    // horizontal base of the tail
+    tail.drawEllipse(50, 108, 40, 12);
+    // curled end pointing upward
+    tail.drawEllipse(85, 90, 12, 20);
     tail.endFill();
+    tail.zIndex = -1;
     c.addChild(tail);
 
     // Head
@@ -304,6 +310,10 @@ async function start(): Promise<void> {
 
   function applyPartColor(part: keyof CatColors, color: number): void {
     (currentColors as any)[part] = color;
+
+    if (currentColors.belly === currentColors.body) {
+      currentColors.belly = shadeColor(currentColors.body, 0.2);
+    }
 
     if (currentCat) {
       avatarContainer.removeChild(currentCat);


### PR DESCRIPTION
## Summary
- allow customizing belly color separately from body
- prevent belly color from matching body color
- draw tail behind the body, lying on the ground with a curled end
- document belly color selection in README

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_688aa9639768832db6e105a6163d4680