### PR TITLE
Add new customization options

### DIFF
--- a/index.html
+++ b/index.html
@@ -99,16 +99,31 @@
     <div class="color-column">
       <div class="column-label">Tail</div>
       <button class="color-btn" data-part="tail" data-color="#ffffff" style="background:#ffffff"></button>
+      <button class="color-btn" data-part="tail" data-color="#808080" style="background:#808080"></button>
       <button class="color-btn" data-part="tail" data-color="#000000" style="background:#000000"></button>
       <button class="color-btn" data-part="tail" data-color="#8b4513" style="background:#8b4513"></button>
       <button class="color-btn" data-part="tail" data-color="#ff9900" style="background:#ff9900"></button>
     </div>
     <div class="color-column">
+      <div class="column-label">Tail Tip</div>
+      <button class="color-btn" data-part="tailTip" data-color="#ffffff" style="background:#ffffff"></button>
+      <button class="color-btn" data-part="tailTip" data-color="#808080" style="background:#808080"></button>
+      <button class="color-btn" data-part="tailTip" data-color="#000000" style="background:#000000"></button>
+      <button class="color-btn" data-part="tailTip" data-color="#ff9900" style="background:#ff9900"></button>
+    </div>
+    <div class="color-column">
       <div class="column-label">Eyes</div>
       <button class="color-btn" data-part="eyes" data-color="#00ff00" style="background:#00ff00"></button>
-      <button class="color-btn" data-part="eyes" data-color="#0000ff" style="background:#0000ff"></button>
+      <button class="color-btn" data-part="eyes" data-color="#66ccff" style="background:#66ccff"></button>
       <button class="color-btn" data-part="eyes" data-color="#ffff00" style="background:#ffff00"></button>
       <button class="color-btn" data-part="eyes" data-color="#ff9900" style="background:#ff9900"></button>
+    </div>
+    <div class="color-column">
+      <div class="column-label">Nose</div>
+      <button class="color-btn" data-part="nose" data-color="#000000" style="background:#000000"></button>
+      <button class="color-btn" data-part="nose" data-color="#ffcccc" style="background:#ffcccc"></button>
+      <button class="color-btn" data-part="nose" data-color="#8b4513" style="background:#8b4513"></button>
+      <button class="color-btn" data-part="nose" data-color="#808080" style="background:#808080"></button>
     </div>
   </div>
 </body>

--- a/src/main.ts
+++ b/src/main.ts
@@ -7,7 +7,9 @@ type CatColors = {
   muzzle: number;
   paws: number;
   tail: number;
+  tailTip: number;
   eyes: number;
+  nose: number;
 };
 
 function shadeColor(color: number, percent: number): number {
@@ -74,7 +76,9 @@ async function start(): Promise<void> {
     muzzle: 0xcccccc,
     paws: 0xaaaaaa,
     tail: 0xffffff,
+    tailTip: 0xffffff,
     eyes: 0x00ff00,
+    nose: 0x000000,
   };
 
   let currentColors: CatColors = { ...defaultColors };
@@ -132,26 +136,26 @@ async function start(): Promise<void> {
     // Front legs
     const legLeft = new PIXI.Graphics();
     legLeft.beginFill(colors.body);
-    legLeft.drawRect(-25, 70, 10, 35);
+    legLeft.drawRect(-27, 70, 14, 70);
     legLeft.endFill();
     c.addChild(legLeft);
 
     const legRight = new PIXI.Graphics();
     legRight.beginFill(colors.body);
-    legRight.drawRect(15, 70, 10, 35);
+    legRight.drawRect(13, 70, 14, 70);
     legRight.endFill();
     c.addChild(legRight);
 
     // Front paws
     const pawLeft = new PIXI.Graphics();
     pawLeft.beginFill(colors.paws);
-    pawLeft.drawEllipse(-20, 105, 15, 8);
+    pawLeft.drawEllipse(-20, 140, 15, 8);
     pawLeft.endFill();
     c.addChild(pawLeft);
 
     const pawRight = new PIXI.Graphics();
     pawRight.beginFill(colors.paws);
-    pawRight.drawEllipse(20, 105, 15, 8);
+    pawRight.drawEllipse(20, 140, 15, 8);
     pawRight.endFill();
     c.addChild(pawRight);
 
@@ -159,30 +163,34 @@ async function start(): Promise<void> {
     const pawPadColor = 0xeeeeee;
     const pawLeftPads = new PIXI.Graphics();
     pawLeftPads.beginFill(pawPadColor);
-    pawLeftPads.drawCircle(-25, 105, 3);
-    pawLeftPads.drawCircle(-20, 103, 3);
-    pawLeftPads.drawCircle(-15, 105, 3);
+    pawLeftPads.drawCircle(-25, 140, 3);
+    pawLeftPads.drawCircle(-20, 138, 3);
+    pawLeftPads.drawCircle(-15, 140, 3);
     pawLeftPads.endFill();
     c.addChild(pawLeftPads);
 
     const pawRightPads = new PIXI.Graphics();
     pawRightPads.beginFill(pawPadColor);
-    pawRightPads.drawCircle(15, 105, 3);
-    pawRightPads.drawCircle(20, 103, 3);
-    pawRightPads.drawCircle(25, 105, 3);
+    pawRightPads.drawCircle(15, 140, 3);
+    pawRightPads.drawCircle(20, 138, 3);
+    pawRightPads.drawCircle(25, 140, 3);
     pawRightPads.endFill();
     c.addChild(pawRightPads);
 
     // Tail drawn behind the body, lying on the ground with a curl
-    const tail = new PIXI.Graphics();
-    tail.beginFill(colors.tail);
-    // horizontal base of the tail
-    tail.drawEllipse(50, 108, 40, 12);
-    // curled end pointing upward
-    tail.drawEllipse(85, 90, 12, 20);
-    tail.endFill();
-    tail.zIndex = -1;
-    c.addChild(tail);
+    const tailBase = new PIXI.Graphics();
+    tailBase.beginFill(colors.tail);
+    tailBase.drawEllipse(50, 108, 40, 12);
+    tailBase.endFill();
+    tailBase.zIndex = -1;
+    c.addChild(tailBase);
+
+    const tailTip = new PIXI.Graphics();
+    tailTip.beginFill(colors.tailTip);
+    tailTip.drawEllipse(85, 90, 12, 20);
+    tailTip.endFill();
+    tailTip.zIndex = -1;
+    c.addChild(tailTip);
 
     // Head
     const head = new PIXI.Container();
@@ -268,7 +276,7 @@ async function start(): Promise<void> {
 
     // Nose
     const nose = new PIXI.Graphics();
-    nose.beginFill(0x000000);
+    nose.beginFill(colors.nose);
     nose.drawCircle(0, 5, 3);
     nose.endFill();
     head.addChild(nose);


### PR DESCRIPTION
## Summary
- extend `CatColors` to include nose and tail tip
- expose color buttons for tail tip and nose
- offer grey as a tail color and lighten blue eye option
- allow longer legs and updated paw locations
- split tail base and tip for separate coloring

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_688aaae7cd3c832d95d46aa1a24962dc