### PR TITLE
Improve cat customization

### DIFF
--- a/index.html
+++ b/index.html
@@ -121,7 +121,7 @@
     <div class="color-column">
       <div class="column-label">Nose</div>
       <button class="color-btn" data-part="nose" data-color="#000000" style="background:#000000"></button>
-      <button class="color-btn" data-part="nose" data-color="#ffcccc" style="background:#ffcccc"></button>
+      <button class="color-btn" data-part="nose" data-special="halfBlackGrey" style="background:linear-gradient(90deg,#000000 50%,#808080 50%)"></button>
       <button class="color-btn" data-part="nose" data-color="#8b4513" style="background:#8b4513"></button>
       <button class="color-btn" data-part="nose" data-color="#808080" style="background:#808080"></button>
     </div>


### PR DESCRIPTION
## Summary
- persist selected cat colors across sessions
- adjust leg and paw positions
- add half black/grey nose option
- slim and reposition tail with straight divider line

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_688aad390334832d825844b987cffcdc