### PR TITLE
Add stripes and accessories

### DIFF
--- a/index.html
+++ b/index.html
@@ -103,6 +103,8 @@
       <button class="color-btn" data-part="tail" data-color="#000000" style="background:#000000"></button>
       <button class="color-btn" data-part="tail" data-color="#8b4513" style="background:#8b4513"></button>
       <button class="color-btn" data-part="tail" data-color="#ff9900" style="background:#ff9900"></button>
+      <button class="color-btn" data-part="tail" data-special="orangeStripes" style="background:repeating-linear-gradient(135deg,#ff9900 0 10px,#000000 10px 20px)"></button>
+      <button class="color-btn" data-part="tail" data-special="greyStripes" style="background:repeating-linear-gradient(135deg,#cccccc 0 10px,#555555 10px 20px)"></button>
     </div>
     <div class="color-column">
       <div class="column-label">Tail Tip</div>
@@ -124,6 +126,12 @@
       <button class="color-btn" data-part="nose" data-special="halfBlackGrey" style="background:linear-gradient(90deg,#000000 50%,#808080 50%)"></button>
       <button class="color-btn" data-part="nose" data-color="#8b4513" style="background:#8b4513"></button>
       <button class="color-btn" data-part="nose" data-color="#808080" style="background:#808080"></button>
+    </div>
+    <div class="color-column">
+      <div class="column-label">Accessory</div>
+      <label style="color:white;font-family:sans-serif;font-size:14px;"><input type="radio" name="accessory" value="none" checked> None</label>
+      <label style="color:white;font-family:sans-serif;font-size:14px;"><input type="radio" name="accessory" value="topHat"> Top Hat</label>
+      <label style="color:white;font-family:sans-serif;font-size:14px;"><input type="radio" name="accessory" value="necklace"> Necklace</label>
     </div>
   </div>
 </body>


### PR DESCRIPTION
## Summary
- add striped tail color choices
- lengthen the tail shape
- implement accessory radio buttons for top hat and necklace
- remember chosen accessories in localStorage

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_688b982dca10832d802e6e7dd147e96f