### PR TITLE
Adjust accessories and color options

### DIFF
--- a/index.html
+++ b/index.html
@@ -53,7 +53,6 @@
 <body>
   <div id="button-bar">
     <button id="create-avatar-btn">Create Avatar</button>
-    <button id="settings-btn">Settings</button>
     <button id="quit-btn">Play</button>
   </div>
   <canvas id="game-canvas"></canvas>
@@ -81,6 +80,7 @@
       <button class="color-btn" data-part="belly" data-color="#ffe4c4" style="background:#ffe4c4"></button>
       <button class="color-btn" data-part="belly" data-color="#f5deb3" style="background:#f5deb3"></button>
       <button class="color-btn" data-part="belly" data-color="#ffffff" style="background:#ffffff"></button>
+      <button class="color-btn" data-part="belly" data-color="#808080" style="background:#808080"></button>
     </div>
     <div class="color-column">
       <div class="column-label">Muzzle</div>

--- a/src/main.ts
+++ b/src/main.ts
@@ -378,16 +378,26 @@ async function start(): Promise<void> {
     if (accessory === 'topHat') {
       const hat = new PIXI.Graphics();
       hat.beginFill(0x000000);
-      hat.drawRect(-20, -85, 40, 30);
-      hat.drawRect(-30, -55, 60, 10);
+      hat.drawRect(-20, -65, 40, 30);
+      hat.drawRect(-30, -35, 60, 10);
       hat.endFill();
       hat.zIndex = 12;
       head.addChild(hat);
     } else if (accessory === 'necklace') {
-      const necklace = new PIXI.Graphics();
-      necklace.setStrokeStyle({ width: 4, color: 0xffd700 });
-      necklace.drawEllipse(0, 50, 28, 10);
-      necklace.stroke();
+      const necklace = new PIXI.Container();
+      const beads = 12;
+      const a = 20;
+      const baseY = 25;
+      for (let i = 0; i <= beads; i++) {
+        const t = (i / beads) * 2 - 1;
+        const x = t * 28;
+        const y = baseY + a * (Math.cosh(x / a) - 1);
+        const bead = new PIXI.Graphics();
+        bead.beginFill(0xffd700);
+        bead.drawCircle(x, y, 3);
+        bead.endFill();
+        necklace.addChild(bead);
+      }
       necklace.zIndex = 12;
       c.addChild(necklace);
     }


### PR DESCRIPTION
## Summary
- remove unused Settings button from menu
- position top hat so rim rests on the cat's head
- render the necklace as catenary beads below the head
- add grey belly color option

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_688b9afb0d68832d8469609a9f243ee8