### PR TITLE
Add randomized meow bubble positions

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -437,10 +437,16 @@ async function start(): Promise<void> {
     }
 
     // Word bubble that occasionally displays "meow!"
+    // Word bubble and connector that display "meow!" from random spots
     const bubble = new PIXI.Container();
     bubble.visible = false;
     bubble.zIndex = 20;
-    bubble.position.set(0, -80);
+
+    // Line from the head to the word bubble so it's clear who's speaking
+    const bubbleConnector = new PIXI.Graphics();
+    bubbleConnector.visible = false;
+    bubbleConnector.zIndex = 19; // slightly behind the bubble
+    head.addChild(bubbleConnector);
 
     const bubbleShape = new PIXI.Graphics();
     bubbleShape.setStrokeStyle({ width: 2, color: 0x000000 });
@@ -465,9 +471,23 @@ async function start(): Promise<void> {
     function scheduleMeow(): void {
       const delay = 3000 + Math.random() * 7000;
       const show = setTimeout(() => {
+        // Randomize bubble position around the head each time it appears
+        const angle = Math.random() * Math.PI * 2;
+        const radius = 70;
+        bubble.position.set(Math.cos(angle) * radius, Math.sin(angle) * radius);
+
+        // Draw the connector line from the head to the bubble
+        bubbleConnector.visible = true;
+        bubbleConnector.clear();
+        bubbleConnector.setStrokeStyle({ width: 2, color: 0x000000 });
+        bubbleConnector.moveTo(0, 0);
+        bubbleConnector.lineTo(bubble.position.x, bubble.position.y);
+        bubbleConnector.stroke();
+
         bubble.visible = true;
         const hide = setTimeout(() => {
           bubble.visible = false;
+          bubbleConnector.visible = false;
           scheduleMeow();
         }, 1000);
         timeouts.push(hide);

--- a/tasks.txt
+++ b/tasks.txt
@@ -4,3 +4,5 @@
 - Add grey as a color option for the ears.
 - Add a split green/blue eye color option (left eye green, right eye blue).
 - Cat occasionally utters a brief 'meow!' in a word bubble.
+- The 'meow' bubble appears in different spots around the head with a line
+  connecting it to the cat.


### PR DESCRIPTION
## Summary
- move the meow bubble around the cat's head when it appears
- draw a short line from the head to the bubble
- record the new requirement

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_688ce3dd2ed4832d88ffed069748b321