### PR TITLE
Improve paw whack animation

### DIFF
--- a/tasks.txt
+++ b/tasks.txt
@@ -12,3 +12,4 @@
 - Add a reddish eye color option styled for albino cats.
 - Add black as a selectable paws color.
 - Cat intermittently animates: ear twitch, whisker twitch, tail flick, blinking and looking eyes, and a paw whack with a "WHACK!" effect.
+- Paw whack animation lasts longer with a three-stage motion, the paw enlarges as it swings, and the WHACK text appears over a yellow starburst.


### PR DESCRIPTION
## Summary
- extend paw whack animation with three stages
- enlarge paw during the swing
- add starburst effect behind "WHACK" text
- document new requirement

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_688cf373175c832dbc7917e4f96276e1