### PR TITLE
Highlight selected color buttons and add black muzzle option

### DIFF
--- a/index.html
+++ b/index.html
@@ -48,6 +48,12 @@
       border: 2px solid #444;
       cursor: pointer;
     }
+
+    /* Selected color is highlighted with a thicker yellow border */
+    .color-btn.selected {
+      border-color: #ffff00;
+      border-width: 4px;
+    }
   </style>
 </head>
 <body>
@@ -89,6 +95,7 @@
       <button class="color-btn" data-part="muzzle" data-color="#ffe4c4" style="background:#ffe4c4"></button>
       <button class="color-btn" data-part="muzzle" data-color="#f5deb3" style="background:#f5deb3"></button>
       <button class="color-btn" data-part="muzzle" data-color="#ffffff" style="background:#ffffff"></button>
+      <button class="color-btn" data-part="muzzle" data-color="#000000" style="background:#000000"></button>
     </div>
     <div class="color-column">
       <div class="column-label">Paws</div>

--- a/src/main.ts
+++ b/src/main.ts
@@ -75,6 +75,24 @@ async function start(): Promise<void> {
     document.querySelectorAll<HTMLButtonElement>('.color-btn')
   );
 
+  // Highlight the button representing the currently selected color for each part
+  function updateColorButtonHighlights(): void {
+    colorButtons.forEach((btn) => {
+      const part = btn.dataset.part as keyof CatColors | undefined;
+      if (!part) return;
+      const current = (currentColors as any)[part];
+      const special = btn.dataset.special;
+      const colorStr = btn.dataset.color;
+      let matches = false;
+      if (special) {
+        matches = current === special;
+      } else if (colorStr) {
+        matches = current === parseInt(colorStr.replace('#', ''), 16);
+      }
+      btn.classList.toggle('selected', matches);
+    });
+  }
+
   const defaultColors: CatColors = {
     ears: 0xffffff,
     body: 0xffffff,
@@ -676,6 +694,8 @@ async function start(): Promise<void> {
     if (currentCat) {
       redrawCat();
     }
+
+    updateColorButtonHighlights();
   }
 
   let currentCat: PIXI.Container | null = null;
@@ -684,6 +704,7 @@ async function start(): Promise<void> {
     buttonBar.style.display = 'none';
     doneBtn.style.display = 'block';
     colorButtonsDiv.style.display = 'flex';
+    updateColorButtonHighlights();
 
     if (!currentCat) {
       currentCat = createCat(currentColors, currentAccessory);

--- a/tasks.txt
+++ b/tasks.txt
@@ -13,3 +13,5 @@
 - Add black as a selectable paws color.
 - Cat intermittently animates: ear twitch, whisker twitch, tail flick, blinking and looking eyes, and a paw whack with a "WHACK!" effect.
 - Paw whack animation lasts longer with a three-stage motion, the paw enlarges as it swings, and the WHACK text appears over a yellow starburst.
+- Current color selections are clearly highlighted in the character creator.
+- Add black as a selectable muzzle color.


### PR DESCRIPTION
## Summary
- highlight chosen color buttons with thicker yellow border
- include black in muzzle color palette
- track color selection changes in JS to update highlights
- record new requirements

## Testing
- `npm run build`
- `npx tsc --noEmit`


------
https://chatgpt.com/codex/tasks/task_e_688cf6a09d6c832d8ce8428a2cce8ffa