### PR TITLE
Implement multiple cat save and UI updates

### DIFF
--- a/index.html
+++ b/index.html
@@ -77,7 +77,7 @@
     <input id="cat-name-input" type="text" style="width:120px;" placeholder="Cat name" />
     <button id="save-cat-btn">Save</button>
   </div>
-  <button id="done-btn" style="display: none; position: absolute; bottom: 20px; left: 50%; transform: translateX(-50%); z-index: 100;">Done</button>
+  <button id="back-btn" style="display: none; position: absolute; top: 20px; left: 20px; z-index: 100;">Back</button>
   <div id="color-buttons">
     <div class="color-column">
       <div class="column-label">Ears</div>

--- a/src/main.ts
+++ b/src/main.ts
@@ -69,7 +69,7 @@ async function start(): Promise<void> {
   const createAvatarBtn = document.getElementById(
     'create-avatar-btn'
   ) as HTMLButtonElement;
-  const doneBtn = document.getElementById('done-btn') as HTMLButtonElement;
+  const backBtn = document.getElementById('back-btn') as HTMLButtonElement;
   const colorButtonsDiv = document.getElementById('color-buttons') as HTMLDivElement;
   const saveRow = document.getElementById('save-row') as HTMLDivElement;
   const catNameInput = document.getElementById('cat-name-input') as HTMLInputElement;
@@ -725,7 +725,7 @@ async function start(): Promise<void> {
 
   function showCharacterCreator(): void {
     buttonBar.style.display = 'none';
-    doneBtn.style.display = 'block';
+    backBtn.style.display = 'block';
     colorButtonsDiv.style.display = 'flex';
     saveRow.style.display = 'block';
     savedCatsContainer.visible = true;
@@ -748,7 +748,7 @@ async function start(): Promise<void> {
 
   function hideCharacterCreator(): void {
     buttonBar.style.display = 'flex';
-    doneBtn.style.display = 'none';
+    backBtn.style.display = 'none';
     colorButtonsDiv.style.display = 'none';
     saveRow.style.display = 'none';
     savedCatsContainer.visible = false;
@@ -769,7 +769,7 @@ async function start(): Promise<void> {
   function positionSavedCats(): void {
     let totalHeight = savedCatsContainer.height;
     savedCatsContainer.position.set(
-      app.screen.width / 2 - 220,
+      app.screen.width / 2 - 260,
       app.screen.height / 2 - totalHeight / 2
     );
   }
@@ -817,8 +817,10 @@ async function start(): Promise<void> {
   function saveCurrentCat(): void {
     const name = catNameInput.value.trim() || 'Unnamed';
     const data = { name, colors: { ...currentColors }, accessory: currentAccessory };
-    if (currentCatIndex >= 0) {
-      savedCats[currentCatIndex] = data;
+    const existingIndex = savedCats.findIndex((c) => c.name === name);
+    if (existingIndex >= 0) {
+      savedCats[existingIndex] = data;
+      currentCatIndex = existingIndex;
     } else {
       savedCats.push(data);
       currentCatIndex = savedCats.length - 1;
@@ -828,7 +830,7 @@ async function start(): Promise<void> {
   }
 
   createAvatarBtn.addEventListener('click', showCharacterCreator);
-  doneBtn.addEventListener('click', hideCharacterCreator);
+  backBtn.addEventListener('click', hideCharacterCreator);
   saveCatBtn.addEventListener('click', saveCurrentCat);
 
   colorButtons.forEach((btn) => {

--- a/tasks.txt
+++ b/tasks.txt
@@ -18,3 +18,6 @@
 - Users can save multiple named cats. A list of saved names with mini portraits
   appears left of the cat during editing. Clicking a name loads that cat. The
   name field under the cat with a save button updates or adds a saved entry.
+- Saving with a new name adds a new entry instead of overwriting the current cat.
+- The list of saved cats is positioned slightly further left.
+- The Done button is now labeled "Back" and sits in the upper left corner.


### PR DESCRIPTION
## Summary
- allow new cat names to create additional saved entries
- place saved cat list slightly further left
- rename **Done** button to **Back** and move it to the upper left
- document new functionality in tasks list

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_688cfcae8834832d82e21ab32b36d9a1