### PR TITLE
feat: support multiple named cat saves

### DIFF
--- a/index.html
+++ b/index.html
@@ -54,6 +54,24 @@
       border-color: #ffff00;
       border-width: 4px;
     }
+
+    #cat-name-input {
+      display: none;
+      position: absolute;
+      bottom: 100px;
+      left: 50%;
+      transform: translateX(-50%);
+      z-index: 100;
+    }
+
+    #save-cat-btn {
+      display: none;
+      position: absolute;
+      bottom: 60px;
+      left: 50%;
+      transform: translateX(-50%);
+      z-index: 100;
+    }
   </style>
 </head>
 <body>
@@ -62,6 +80,8 @@
     <button id="quit-btn">Play</button>
   </div>
   <canvas id="game-canvas"></canvas>
+  <input id="cat-name-input" type="text" placeholder="Cat Name" />
+  <button id="save-cat-btn">Save</button>
   <button id="done-btn" style="display: none; position: absolute; bottom: 20px; left: 50%; transform: translateX(-50%); z-index: 100;">Done</button>
   <div id="color-buttons">
     <div class="color-column">

--- a/src/main.ts
+++ b/src/main.ts
@@ -18,6 +18,12 @@ type CatColors = {
 
 type Accessory = 'none' | 'topHat' | 'necklace';
 
+type SavedCat = {
+  name: string;
+  colors: CatColors;
+  accessory: Accessory;
+};
+
 function shadeColor(color: number, percent: number): number {
   const r = (color >> 16) & 0xff;
   const g = (color >> 8) & 0xff;
@@ -74,6 +80,8 @@ async function start(): Promise<void> {
   const colorButtons = Array.from(
     document.querySelectorAll<HTMLButtonElement>('.color-btn')
   );
+  const nameInput = document.getElementById('cat-name-input') as HTMLInputElement;
+  const saveCatBtn = document.getElementById('save-cat-btn') as HTMLButtonElement;
 
   // Highlight the button representing the currently selected color for each part
   function updateColorButtonHighlights(): void {
@@ -120,6 +128,18 @@ async function start(): Promise<void> {
   const savedAccessory = localStorage.getItem('catAccessory');
   if (savedAccessory === 'topHat' || savedAccessory === 'necklace' || savedAccessory === 'none') {
     currentAccessory = savedAccessory as Accessory;
+  }
+
+  // Saved cat list and display column
+  const savedCatsContainer = new PIXI.Container();
+  let savedCats: SavedCat[] = [];
+  const savedCatsRaw = localStorage.getItem('savedCats');
+  if (savedCatsRaw) {
+    try {
+      savedCats = JSON.parse(savedCatsRaw) as SavedCat[];
+    } catch {
+      /* ignore malformed saved data */
+    }
   }
 
   // Container for the avatar model
@@ -704,6 +724,9 @@ async function start(): Promise<void> {
     buttonBar.style.display = 'none';
     doneBtn.style.display = 'block';
     colorButtonsDiv.style.display = 'flex';
+    nameInput.style.display = 'block';
+    saveCatBtn.style.display = 'block';
+    nameInput.value = '';
     updateColorButtonHighlights();
 
     if (!currentCat) {
@@ -711,7 +734,10 @@ async function start(): Promise<void> {
       avatarContainer.addChild(currentCat);
       app.stage.addChild(avatarContainer);
     }
-
+    if (!app.stage.children.includes(savedCatsContainer)) {
+      app.stage.addChild(savedCatsContainer);
+    }
+    renderSavedCats();
     positionAvatar();
   }
 
@@ -719,6 +745,8 @@ async function start(): Promise<void> {
     buttonBar.style.display = 'flex';
     doneBtn.style.display = 'none';
     colorButtonsDiv.style.display = 'none';
+    nameInput.style.display = 'none';
+    saveCatBtn.style.display = 'none';
 
     if (currentCat) {
       avatarContainer.removeChild(currentCat);
@@ -726,11 +754,18 @@ async function start(): Promise<void> {
       currentCat.destroy();
       currentCat = null;
     }
+
+    savedCatsContainer.removeChildren().forEach((c) => c.destroy());
+    if (app.stage.children.includes(savedCatsContainer)) {
+      app.stage.removeChild(savedCatsContainer);
+    }
   }
 
   function positionAvatar(): void {
-    if (!currentCat) return;
-    currentCat.position.set(app.screen.width / 2, app.screen.height / 2);
+    if (currentCat) {
+      currentCat.position.set(app.screen.width / 2, app.screen.height / 2);
+    }
+    savedCatsContainer.position.set(app.screen.width / 2 - 150, app.screen.height / 2);
   }
 
   createAvatarBtn.addEventListener('click', showCharacterCreator);
@@ -776,6 +811,75 @@ async function start(): Promise<void> {
       }
     });
   });
+
+  // Load the given saved cat into the editor for further tweaking
+  function loadSavedCat(cat: SavedCat): void {
+    currentColors = { ...cat.colors };
+    currentAccessory = cat.accessory;
+    localStorage.setItem('catColors', JSON.stringify(currentColors));
+    localStorage.setItem('catAccessory', currentAccessory);
+    accessoryRadios.forEach((r) => {
+      r.checked = r.value === currentAccessory;
+    });
+    nameInput.value = cat.name;
+    if (currentCat) {
+      redrawCat();
+    }
+    updateColorButtonHighlights();
+  }
+
+  // Draw the vertical list of saved cats with miniature previews
+  function renderSavedCats(): void {
+    savedCatsContainer.removeChildren().forEach((c) => c.destroy());
+    const entryHeight = 60;
+    const startY = -((savedCats.length - 1) * entryHeight) / 2;
+    savedCats.forEach((cat, i) => {
+      const entry = new PIXI.Container();
+      entry.y = startY + i * entryHeight;
+      entry.eventMode = 'static';
+      entry.cursor = 'pointer';
+
+      const mini = createCat(cat.colors, cat.accessory);
+      const scale = 0.3;
+      mini.scale.set(scale);
+      mini.position.set(-40, -50 * scale);
+      entry.addChild(mini);
+
+      const label = new PIXI.Text(cat.name, {
+        fill: 0xffffff,
+        fontSize: 14,
+        fontFamily: 'sans-serif',
+      });
+      label.x = 20;
+      label.y = -10;
+      entry.addChild(label);
+
+      entry.on('pointertap', () => loadSavedCat(cat));
+      savedCatsContainer.addChild(entry);
+    });
+    positionAvatar();
+  }
+
+  // Save the currently edited cat under the provided name
+  function saveCurrentCat(): void {
+    const name = nameInput.value.trim();
+    if (!name) return;
+    const existing = savedCats.find((c) => c.name === name);
+    if (existing) {
+      existing.colors = { ...currentColors };
+      existing.accessory = currentAccessory;
+    } else {
+      savedCats.push({
+        name,
+        colors: { ...currentColors },
+        accessory: currentAccessory,
+      });
+    }
+    localStorage.setItem('savedCats', JSON.stringify(savedCats));
+    renderSavedCats();
+  }
+
+  saveCatBtn.addEventListener('click', saveCurrentCat);
 
   app.renderer.on('resize', positionAvatar);
 

--- a/tasks.txt
+++ b/tasks.txt
@@ -15,3 +15,4 @@
 - Paw whack animation lasts longer with a three-stage motion, the paw enlarges as it swings, and the WHACK text appears over a yellow starburst.
 - Current color selections are clearly highlighted in the character creator.
 - Add black as a selectable muzzle color.
+- Allow saving multiple named cat characters with a selectable list of mini cats on the left and a name field with save button for editing.


### PR DESCRIPTION
## Summary
- allow naming and saving multiple cats via new input and save button
- display saved cats in a left-hand list with miniature previews for easy loading
- record requirement to tasks list

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_689b969ba914832d86f88258d0b87321