### PR TITLE
feat: save and load named cats

### DIFF
--- a/index.html
+++ b/index.html
@@ -54,6 +54,42 @@
       border-color: #ffff00;
       border-width: 4px;
     }
+
+    /* List of saved cats shown to the left of the editor */
+    #saved-cats {
+      position: absolute;
+      top: 50%;
+      left: calc(50% - 250px);
+      transform: translateY(-50%);
+      display: none;
+      flex-direction: column;
+      gap: 10px;
+      z-index: 100;
+    }
+
+    .saved-cat-entry {
+      display: flex;
+      align-items: center;
+      gap: 6px;
+      cursor: pointer;
+      color: #ffffff;
+      font-family: sans-serif;
+      font-size: 14px;
+    }
+
+    .saved-cat-entry canvas {
+      border: 1px solid #444;
+    }
+
+    /* Name field and save button below the cat */
+    #name-save-bar {
+      display: none;
+      position: absolute;
+      bottom: 60px;
+      left: 50%;
+      transform: translateX(-50%);
+      z-index: 100;
+    }
   </style>
 </head>
 <body>
@@ -146,6 +182,11 @@
       <label style="color:white;font-family:sans-serif;font-size:14px;"><input type="radio" name="accessory" value="topHat"> Top Hat</label>
       <label style="color:white;font-family:sans-serif;font-size:14px;"><input type="radio" name="accessory" value="necklace"> Necklace</label>
     </div>
+  </div>
+  <div id="saved-cats"></div>
+  <div id="name-save-bar">
+    <input id="cat-name" type="text" placeholder="Name" />
+    <button id="save-cat-btn">Save</button>
   </div>
 </body>
 </html>

--- a/src/main.ts
+++ b/src/main.ts
@@ -18,6 +18,12 @@ type CatColors = {
 
 type Accessory = 'none' | 'topHat' | 'necklace';
 
+type SavedCat = {
+  name: string;
+  colors: CatColors;
+  accessory: Accessory;
+};
+
 function shadeColor(color: number, percent: number): number {
   const r = (color >> 16) & 0xff;
   const g = (color >> 8) & 0xff;
@@ -74,6 +80,10 @@ async function start(): Promise<void> {
   const colorButtons = Array.from(
     document.querySelectorAll<HTMLButtonElement>('.color-btn')
   );
+  const savedCatsDiv = document.getElementById('saved-cats') as HTMLDivElement;
+  const nameInput = document.getElementById('cat-name') as HTMLInputElement;
+  const saveCatBtn = document.getElementById('save-cat-btn') as HTMLButtonElement;
+  const nameSaveBar = document.getElementById('name-save-bar') as HTMLDivElement;
 
   // Highlight the button representing the currently selected color for each part
   function updateColorButtonHighlights(): void {
@@ -91,6 +101,46 @@ async function start(): Promise<void> {
       }
       btn.classList.toggle('selected', matches);
     });
+  }
+
+  async function renderSavedCats(): Promise<void> {
+    thumbApps.forEach((a) => a.destroy(true));
+    thumbApps.length = 0;
+    savedCatsDiv.innerHTML = '';
+    for (const cat of savedCats) {
+      const entry = document.createElement('div');
+      entry.className = 'saved-cat-entry';
+      const canvas = document.createElement('canvas');
+      canvas.width = 50;
+      canvas.height = 50;
+      entry.appendChild(canvas);
+      const label = document.createElement('span');
+      label.textContent = cat.name;
+      entry.appendChild(label);
+      savedCatsDiv.appendChild(entry);
+
+      const t = new PIXI.Application();
+      await t.init({ view: canvas, width: 50, height: 50, backgroundAlpha: 0 });
+      const mini = createCat(cat.colors, cat.accessory);
+      mini.scale.set(0.3);
+      mini.position.set(25, 35);
+      t.stage.addChild(mini);
+      thumbApps.push(t);
+
+      entry.addEventListener('click', () => {
+        currentColors = { ...cat.colors };
+        currentAccessory = cat.accessory;
+        currentCatName = cat.name;
+        nameInput.value = cat.name;
+        localStorage.setItem('catColors', JSON.stringify(currentColors));
+        localStorage.setItem('catAccessory', currentAccessory);
+        accessoryRadios.forEach((r) => {
+          r.checked = r.value === currentAccessory;
+        });
+        redrawCat();
+        updateColorButtonHighlights();
+      });
+    }
   }
 
   const defaultColors: CatColors = {
@@ -121,6 +171,18 @@ async function start(): Promise<void> {
   if (savedAccessory === 'topHat' || savedAccessory === 'necklace' || savedAccessory === 'none') {
     currentAccessory = savedAccessory as Accessory;
   }
+
+  let savedCats: SavedCat[] = [];
+  const savedCatsStr = localStorage.getItem('savedCats');
+  if (savedCatsStr) {
+    try {
+      savedCats = JSON.parse(savedCatsStr) as SavedCat[];
+    } catch {
+      /* ignore malformed saved cat data */
+    }
+  }
+  const thumbApps: PIXI.Application[] = [];
+  let currentCatName = '';
 
   // Container for the avatar model
   const avatarContainer = new PIXI.Container();
@@ -704,6 +766,10 @@ async function start(): Promise<void> {
     buttonBar.style.display = 'none';
     doneBtn.style.display = 'block';
     colorButtonsDiv.style.display = 'flex';
+    savedCatsDiv.style.display = 'flex';
+    nameSaveBar.style.display = 'block';
+    nameInput.value = currentCatName;
+    void renderSavedCats();
     updateColorButtonHighlights();
 
     if (!currentCat) {
@@ -719,6 +785,8 @@ async function start(): Promise<void> {
     buttonBar.style.display = 'flex';
     doneBtn.style.display = 'none';
     colorButtonsDiv.style.display = 'none';
+    savedCatsDiv.style.display = 'none';
+    nameSaveBar.style.display = 'none';
 
     if (currentCat) {
       avatarContainer.removeChild(currentCat);
@@ -776,6 +844,25 @@ async function start(): Promise<void> {
       }
     });
   });
+
+  saveCatBtn.addEventListener('click', async () => {
+    const name = nameInput.value.trim();
+    if (!name) {
+      return;
+    }
+    const existing = savedCats.find((c) => c.name === name);
+    if (existing) {
+      existing.colors = { ...currentColors };
+      existing.accessory = currentAccessory;
+    } else {
+      savedCats.push({ name, colors: { ...currentColors }, accessory: currentAccessory });
+    }
+    localStorage.setItem('savedCats', JSON.stringify(savedCats));
+    currentCatName = name;
+    await renderSavedCats();
+  });
+
+  await renderSavedCats();
 
   app.renderer.on('resize', positionAvatar);
 

--- a/tasks.txt
+++ b/tasks.txt
@@ -15,3 +15,5 @@
 - Paw whack animation lasts longer with a three-stage motion, the paw enlarges as it swings, and the WHACK text appears over a yellow starburst.
 - Current color selections are clearly highlighted in the character creator.
 - Add black as a selectable muzzle color.
+- Saved cat characters can be stored with names and appear in a left-side list with miniature cat thumbnails that load on click.
+- A name field and save button beneath the cat update an existing entry or create a new one when saving with a new name.


### PR DESCRIPTION
## Summary
- add a column of saved cats with miniature thumbnails and names
- allow editing a cat name and saving it to the list

## Testing
- `npm test` (fails: Missing script "test")
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689b969ba914832d86f88258d0b87321